### PR TITLE
Fix: Auth Controller Make sure to await password comparison

### DIFF
--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -14,7 +14,7 @@ export async function loginHandler(
   // find the user by email
   const user = await findUserByEmail(email);
 
-  if (!user || !user.comparePassword(password)) {
+  if (!user || !(await user.comparePassword(password))) {
     return res
       .status(StatusCodes.UNAUTHORIZED)
       .send("Invalid email or password");


### PR DESCRIPTION
Currently, we're not awaiting the password comparison which results in a bug where  the user gets an access token even with an incorrect password cuz we're not waiting for the result from  comparePassword